### PR TITLE
Stick to old version of Twig 1.x, instead of using the new 2.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-        "twig/twig": "*"
+        "twig/twig": "1.x-dev"
     },
     "autoload": {
         "psr-4": { "yii\\twig\\": "" }


### PR DESCRIPTION
As of Twig 1.x, use Twig_SimpleFilter to add a filter. The following classes and interfaces will be removed in 2.0:

    Twig_FilterInterface
    Twig_FilterCallableInterface
    Twig_Filter
    Twig_Filter_Function
    Twig_Filter_Method
    Twig_Filter_Node


Sources:
https://packagist.org/packages/twig/twig
http://twig.sensiolabs.org/doc/deprecated.html