### PR TITLE
added direct access to application properties

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -32,6 +32,11 @@ abstract class Template extends \Twig_Template
                 }
                 return $object->$item;
             }
+        } else if ($object instanceof \yii\base\Application) {
+	        if ($this->env->hasExtension('sandbox')) {
+		        $this->env->getExtension('sandbox')->checkPropertyAllowed($object, $item);
+	        }
+	        return $object->$item;
         }
 
         return parent::getAttribute($object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck);


### PR DESCRIPTION
ref #24 
It's *__isset()* of ServiceLocator problem.
Try it:

```php
$isIssetUrlManager = isset(Yii::$app->urlManager);
$isIssetYouService = isset(Yii::$app->youService);
VarDumper::dump([$isIssetUrlManager, $isIssetYouService]);
```

$isIssetUrlManager is true, $isIssetYouService is false.
Twig return null in this line: https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Template.php#L466 and it's means that **all your cusom components is unavalible in twig template**.

Hotfix:

Make new file, in my case it's BaseYii.php
```php
<?php

class Yii extends \yii\BaseYii
{
    /**
     * @var BaseApplication|WebApplication|ConsoleApplication
     */
    public static $app;
}

spl_autoload_register(['Yii', 'autoload'], true, true);
Yii::$classMap = include(__DIR__ . '/../vendor/yiisoft/yii2/classes.php');
Yii::$container = new yii\di\Container;

abstract class BaseApplication extends yii\base\Application
{
}

class WebApplication extends yii\web\Application
{
}

class ConsoleApplication extends yii\console\Application
{
	public function getYouService()
	{
		return $this->get('youService');
	}
}

```

In index.php, yii.php and others initial scripts:
```php
require(__DIR__ . '/common/BaseYii.php');
$application = new ConsoleApplication($config);
```

Thus we make avalible method *getYouService* and method_exist of Yii2 ServiceLocator *__isset* should be return YouService object.

This pull request is solution of this issue.