### PR TITLE
better themes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 twig extension Change Log
 -----------------------
 
 - Enh #16: Extended simple functions and simple filters support (PatchRanger, quantum13)
+- Enh #30: Added `@app/views`, `@app/modules`, `@app/widgets` as `Twig_Loader_Filesystem` loader paths, same for theme `pathMap` paths 
 
 2.0.4 May 10, 2015
 ------------------

--- a/ViewRenderer.php
+++ b/ViewRenderer.php
@@ -90,6 +90,26 @@ class ViewRenderer extends BaseViewRenderer
      */
     public $twig;
 
+    /**
+     * @var string twig namespace to use in templates
+     */
+    public $twigViewsNamespace = \Twig_Loader_Filesystem::MAIN_NAMESPACE;
+
+    /**
+     * @var string twig namespace to use in modules templates
+     */
+    public $twigModulesNamespace = 'modules';
+
+    /**
+     * @var string twig namespace to use in widgets templates
+     */
+    public $twigWidgetsNamespace = 'widgets';
+
+    /**
+     * @var array twig fallback paths
+     */
+    public $twigFallbackPaths = [];
+
 
     public function init()
     {
@@ -146,6 +166,7 @@ class ViewRenderer extends BaseViewRenderer
     {
         $this->twig->addGlobal('this', $view);
         $loader = new \Twig_Loader_Filesystem(dirname($file));
+        $this->addFallbackPaths($loader, $view->theme);
         $this->addAliases($loader, Yii::$aliases);
         $this->twig->setLoader($loader);
 
@@ -166,6 +187,74 @@ class ViewRenderer extends BaseViewRenderer
             } elseif (is_string($path) && is_dir($path)) {
                 $loader->addPath($path, substr($alias, 1));
             }
+        }
+    }
+
+    /**
+     * Adds fallback paths to twig loader
+     *
+     * @param \Twig_Loader_Filesystem $loader
+     * @param \yii\base\Theme|null $theme
+     */
+    protected function addFallbackPaths($loader, $theme)
+    {
+        foreach ($this->twigFallbackPaths as $namespace => $path) {
+            $path = Yii::getAlias($path);
+            if (!is_dir($path)) {
+                continue;
+            }
+
+            if (is_string($namespace)) {
+                $loader->addPath($path, $namespace);
+            } else {
+                $loader->addPath($path);
+            }
+        }
+
+        if ($theme instanceOf \yii\base\Theme && is_array($theme->pathMap)) {
+            $pathMap = $theme->pathMap;
+
+            if (isset($pathMap['@app/views'])) {
+                foreach ((array)$pathMap['@app/views'] as $path) {
+                    $path = Yii::getAlias($path);
+                    if (is_dir($path)) {
+                        $loader->addPath($path, $this->twigViewsNamespace);
+                    }
+                }
+            }
+
+            if (isset($pathMap['@app/modules'])) {
+                foreach ((array)$pathMap['@app/modules'] as $path) {
+                    $path = Yii::getAlias($path);
+                    if (is_dir($path)) {
+                        $loader->addPath($path, $this->twigModulesNamespace);
+                    }
+                }
+            }
+
+            if (isset($pathMap['@app/widgets'])) {
+                foreach ((array)$pathMap['@app/widgets'] as $path) {
+                    $path = Yii::getAlias($path);
+                    if (is_dir($path)) {
+                        $loader->addPath($path, $this->twigWidgetsNamespace);
+                    }
+                }
+            }
+        }
+
+        $defaultViewsPath = Yii::getAlias('@app/views');
+        if (is_dir($defaultViewsPath)) {
+            $loader->addPath($defaultViewsPath, $this->twigViewsNamespace);
+        }
+
+        $defaultModulesPath = Yii::getAlias('@app/modules');
+        if (is_dir($defaultModulesPath)) {
+            $loader->addPath($defaultModulesPath, $this->twigModulesNamespace);
+        }
+
+        $defaultWidgetsPath = Yii::getAlias('@app/widgets');
+        if (is_dir($defaultWidgetsPath)) {
+            $loader->addPath($defaultWidgetsPath, $this->twigWidgetsNamespace);
         }
     }
 


### PR DESCRIPTION
As Twig_Loader_Filesystem provides fallback dirs for templates search,
I suppose we can add '@app/views' and theme pathMap paths for it as default search  paths.
So if in component view config we have something like:
```php
'theme' => [
    'pathMap' => [
       '@app/views' => [
           '@app/themes/theme1',
           '@app/themes/theme2'
       ],
    ],
]
```
And in twig template we have, for example:
```code
 {% extends 'layouts/main.twig' %}
```
 it will be searched for '@app/themes/theme1/layouts/main.twig', then for '@app/themes/theme2/layouts/main.twig' and so on, according to theme inheritance. 
Also we can do same for widgets and modules templates.

Added some options to `ViewRenderer` config:
- `twigViewsNamespace` - how should be aliased '@app/views' and `$pathMap['@app/views']` in twig template; default is `Twig_Loader_Filesystem::MAIN_NAMESPACE`,
- `twigModulesNamespace` and `twigWidgetsNamespace` - for '@app/modules' and `@app/widgets`, 
defaults are: 'modules' and 'widgets'
- `twigFallbackPaths` - an array with paths assigned to `Twig_Loader_Filesystem`, keys are namespaces (if not present, default twig namespace will be used) 