### PR TITLE
Getting rid of deprecated function Twig\Node::getLine() fixes #75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 twig extension Change Log
 
 - Enh #78: Added `ViewRendererStaticClassProxy:__isset()` to be able to access static variable in the template (mrlinqu)
 - Enh #79: Added class constants support (mrlinqu)
+- Enh #75: Got rid of deprecated function `Twig\Node::getLine()` (dmirogin)
 
 
 2.1.0 March 25, 2017

--- a/Optimizer.php
+++ b/Optimizer.php
@@ -34,10 +34,10 @@ class Optimizer implements \Twig_NodeVisitorInterface
             if ($expression instanceof \Twig_Node_Expression_Function) {
                 $name = $expression->getAttribute('name');
                 if (preg_match('/^(?:register_.+_asset|use|.+_begin|.+_end)$/', $name)) {
-                    return new \Twig_Node_Do($expression, $expression->getLine());
+                    return new \Twig_Node_Do($expression, $expression->getTemplateLine());
                 } elseif (in_array($name, ['begin_page', 'end_page', 'begin_body', 'end_body', 'head'])) {
                     $arguments = [
-                        new \Twig_Node_Expression_Constant($name, $expression->getLine()),
+                        new \Twig_Node_Expression_Constant($name, $expression->getTemplateLine()),
                     ];
                     if ($expression->hasNode('arguments') && $expression->getNode('arguments') !== null) {
                         foreach ($expression->getNode('arguments') as $key => $value) {
@@ -49,7 +49,7 @@ class Optimizer implements \Twig_NodeVisitorInterface
                         }
                     }
                     $expression->setNode('arguments', new \Twig_Node($arguments));
-                    return new \Twig_Node_Do($expression, $expression->getLine());
+                    return new \Twig_Node_Do($expression, $expression->getTemplateLine());
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #75 
