### PR TITLE
prevent twig 3.9 from installing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "yiisoft/yii2": "~2.0.4",
         "twig/twig": "~3.0"
     },
+    "conflict": {
+        "twig/twig": ">=3.9"
+    },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
         "phpunit/phpunit": "4.8.34"


### PR DESCRIPTION
see also https://github.com/yiisoft/yii2-twig/pull/154#issuecomment-2072084005 and following

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #153 (workaround)

Should be removed when lib is updated to work correctly with twig 3.9
