### PR TITLE
Fix #159: Fixed string interpolation format for php 8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: ['7.2', '7.3', '7.4', '8.0','8.1']
+                php: ['7.2', '7.3', '7.4', '8.0','8.1','8.2','8.3']
 
         steps:
             - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 twig extension Change Log
 2.5.1 under development
 -----------------------
 
-- no changes in this release.
+- Bug #159: Fixed string interpolation format for php 8.2 (qwerty199369)
 
 
 2.5.0 May 09, 2024

--- a/tests/data/StaticAndConsts.php
+++ b/tests/data/StaticAndConsts.php
@@ -11,6 +11,6 @@ class StaticAndConsts
 
     public static function sticFunction($var)
     {
-        return "I am a static function with param ${var}!";
+        return "I am a static function with param {$var}!";
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
